### PR TITLE
Add inputStyle prop to FieldInput and remove from FieldSelect

### DIFF
--- a/src/components/ui/Fields/FieldInput/FieldInput.jsx
+++ b/src/components/ui/Fields/FieldInput/FieldInput.jsx
@@ -21,6 +21,7 @@ export const FieldInput = ({
                              className = "",
                              helperText,
                              disabled = false,
+                             inputStyle,
                              ...rest // для додаткових пропсів (наприклад, ref)
                            }) => {
 
@@ -91,6 +92,7 @@ export const FieldInput = ({
       onFocus: handleOnFocus, // ADDED: Focus handler
       onBlur: handleOnBlur,
       required,
+      style: inputStyle, // Apply inputStyle as a style object
       ...rest,
     };
 

--- a/src/components/ui/Fields/FieldSelect/FieldSelect.jsx
+++ b/src/components/ui/Fields/FieldSelect/FieldSelect.jsx
@@ -17,7 +17,6 @@ export const FieldSelect = ({
   className,
   helperText,
   disabled = false,
-  inputStyle,
 }) => {
   const fieldId = useId();
   const [isOpen, setIsOpen] = useState(false);


### PR DESCRIPTION
- Added `inputStyle` prop to `FieldInput` to allow custom inline styles for input elements.
- Removed unused `inputStyle` prop from `FieldSelect` for cleanup and consistency.